### PR TITLE
Add js config files to defaultPaths

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -7,7 +7,12 @@ import sucrase from 'sucrase'
 
 // Constants:
 
-const defaultPaths = ['config.ts', 'src/config.ts']
+const defaultPaths = [
+  'config.ts',
+  'config.js',
+  'src/config.ts',
+  'src/config.js'
+]
 
 // Env:
 


### PR DESCRIPTION
Referring to a minor wrinkle in [this pr](https://github.com/EdgeApp/edge-react-gui/pull/3455). We were using `.js` for our config file but the cli wouldn't recognize it if we wanted to run `configure` directly without specifying the file name.